### PR TITLE
Make key functions public so that this plugin can be used as a dependency plugin

### DIFF
--- a/HideVolumeLabelsPlugin/HideVolumeLabelsPlugin.cs
+++ b/HideVolumeLabelsPlugin/HideVolumeLabelsPlugin.cs
@@ -24,7 +24,7 @@ namespace HideVolumeLabelsPlugin
         // constants
         public const string Guid = "org.hollofox.plugins.HideVolumeLabelsPlugin";
         public const string G = "L";
-        private const string Version = "1.0.0.0";
+        private const string Version = "1.0.1.0";
 
         private static Dictionary<HideVolumeItem, Dictionary<string,string>> Labels
             = new Dictionary<HideVolumeItem, Dictionary<string, string>>();
@@ -33,6 +33,13 @@ namespace HideVolumeLabelsPlugin
         private ConfigEntry<Color> baseColor { get; set; }
         private Dictionary<string, string> colorizations = new Dictionary<string, string>();
         private string dir = Application.dataPath.Substring(0, Application.dataPath.LastIndexOf("/")) + "/TaleSpire_CustomData/";
+
+        public static string GetLabel(HideVolumeItem volume, string key)
+        {
+            if (!Labels.ContainsKey(volume)) return "";
+            if (!Labels[volume].ContainsKey(key)) return "";
+            return Labels[volume][key];
+        }
 
         public static void SetLabel(HideVolumeItem volume, string key, string text)
         {
@@ -46,6 +53,21 @@ namespace HideVolumeLabelsPlugin
             else Labels[volume][key] = text;
 
             SaveLabels();
+        }
+
+        public static List<HideVolumeItem> allVolumes()
+        {
+            var a = HideVolumeManager.Instance;
+            var hideVolumes = a.transform.GetChild(1).Children();
+            var allVolumes = new List<HideVolumeItem>();
+            for (int i = 0; i < hideVolumes.LongCount(); i++)
+            {
+                var volume = a.transform.GetChild(1).GetChild(i);
+                var volumeComponent = volume.GetComponent<HideVolumeItem>();
+                allVolumes.Add(volumeComponent);
+            }
+
+            return allVolumes;
         }
 
         private static void SaveLabels()
@@ -62,21 +84,6 @@ namespace HideVolumeLabelsPlugin
             var info = JsonConvert.SerializeObject(toInt);
 
             HolloFoxes.BoardPersistence.SetInfo(G,info);
-        }
-
-        private static List<HideVolumeItem> allVolumes()
-        {
-            var a = HideVolumeManager.Instance;
-            var hideVolumes = a.transform.GetChild(1).Children();
-            var allVolumes = new List<HideVolumeItem>();
-            for (int i = 0; i < hideVolumes.LongCount(); i++)
-            {
-                var volume = a.transform.GetChild(1).GetChild(i);
-                var volumeComponent = volume.GetComponent<HideVolumeItem>();
-                allVolumes.Add(volumeComponent);
-            }
-
-            return allVolumes;
         }
 
         private static bool LoadLabelsError = true;

--- a/HideVolumeLabelsPlugin/Properties/AssemblyInfo.cs
+++ b/HideVolumeLabelsPlugin/Properties/AssemblyInfo.cs
@@ -5,13 +5,13 @@ using System.Runtime.InteropServices;
 // General Information about an assembly is controlled through the following
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
-[assembly: AssemblyTitle("RForRotatePlugin")]
+[assembly: AssemblyTitle("HideVolumeLabelsPlugin")]
 [assembly: AssemblyDescription("")]
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("D20ArmyKnife")]
 [assembly: AssemblyProduct("RForRotatePlugin")]
 [assembly: AssemblyCopyright("Copyright ©  2020")]
-[assembly: AssemblyTrademark("")]
+[assembly: AssemblyTrademark("HideVolumeLabelsPlugin")]
 [assembly: AssemblyCulture("")]
 
 // Setting ComVisible to false makes the types in this assembly not visible
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.0.0.0")]
+[assembly: AssemblyVersion("1.0.1.0")]
+[assembly: AssemblyFileVersion("1.0.1.0")]


### PR DESCRIPTION
Exposed allVolumes() and SetLabel() methods and added GetLabel(). Together these functions can be used to obtain all of the hide volumes and read and set their corresponding labels.

Also corrected plugin properties to indicated the correct plugin name. 